### PR TITLE
Merge regParams and sysParams in a single dataset.

### DIFF
--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -87,10 +87,8 @@ class EconetClient:
                         return None
 
                     return await resp.json()
-            except TimeoutError as error:
-                _LOGGER.warning(
-                    "Timeout error, retry({}/{})".format(attempt, max_attempts)
-                )
+            except TimeoutError:
+                _LOGGER.warning("Timeout error, retry(%i/%i)", attempt, max_attempts)
                 await asyncio.sleep(1)
             finally:
                 attempt += 1

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -72,10 +72,10 @@ class EconetClient:
         return await self._get(url)
 
     async def _get(self, url):
-        attempt = 0
+        attempt = 1
         max_attempts = 5
 
-        while ++attempt <= max_attempts:
+        while attempt <= max_attempts:
             try:
                 async with await self._session.get(
                     url, auth=self._auth, timeout=10
@@ -92,6 +92,8 @@ class EconetClient:
                     "Timeout error, retry({}/{})".format(attempt, max_attempts)
                 )
                 await asyncio.sleep(1)
+            finally:
+                attempt += 1
 
 
 class Econet300Api:


### PR DESCRIPTION
This is [an example](https://github.com/jontofront/ecoNET-300-Home-Assistant-Integration/pull/9/commits/8ce002f5198f068153fdfa8d51981353476b8c9c) on how to merge data fetched from regParams "curr" key and sysParams.
This should be considered unsafe merge as it overrides existing keys and should only be used for learning purposes.
For proper implementation - both endpoints should be merged under different keys and accessed via separate entity sub-classes.

Additionally, [this](https://github.com/jontofront/ecoNET-300-Home-Assistant-Integration/pull/9/commits/6c91daceca6b2ff3774406255d2f7aeb6aa8fe1a) fixes non-working retry logic, due to nonexistent pre-increment operator.
For more information on this, see [pylint documentation](https://pylint.readthedocs.io/en/latest/user_guide/messages/error/nonexistent-operator.html).