### PR TITLE
Fix translations

### DIFF
--- a/custom_components/econet300/binary_sensor.py
+++ b/custom_components/econet300/binary_sensor.py
@@ -36,14 +36,14 @@ class EconetBinarySensorEntityDescription(BinarySensorEntityDescription):
 BINARY_SENSOR_TYPES: tuple[EconetBinarySensorEntityDescription, ...] = (
     EconetBinarySensorEntityDescription(
         key="1544",
-        name="Pump mixer 1",
+        translation_key="mixer_pump1",
         icon="mdi:pump",
         icon_off="mdi:pump-off",
         device_class=BinarySensorDeviceClass.RUNNING,
     ),
     EconetBinarySensorEntityDescription(
         key="1541",
-        name="Boiler pump",
+        translation_key="boiler_pump",
         icon="mdi:pump",
         icon_off="mdi:pump-off",
         device_class=BinarySensorDeviceClass.RUNNING,

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -43,10 +43,6 @@ class EconetSensor(SensorEntity):
         super().__init__(name=name, unique_id=unique_id)
         self.entity_description = entity_description
         self._attr_native_value = None
-    @property
-    def name(self):
-        """Return the localized name of the sensor."""
-        return self.hass.localize(f"econet300.entity.sensor.{self.entity_description.name}")
 
     def _sync_state(self, value):
         """Sync state"""
@@ -80,7 +76,7 @@ def create_entity_description(key: str):
     map_key = REG_PARAM_MAP.get(key, key)
     return EconetSensorEntityDescription(
         key=key,
-        name=camel_to_snake(map_key),
+        translation_key=camel_to_snake(map_key),
         native_unit_of_measurement=REG_PARAM_UNIT.get(map_key, None),
         state_class=REG_PARAM_STATE_CLASS.get(map_key, None),
         device_class=REG_PARAM_DEVICE_CLASS.get(map_key, None),

--- a/custom_components/econet300/strings.json
+++ b/custom_components/econet300/strings.json
@@ -18,28 +18,31 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
-  "entity":{
+  "entity": {
+    "binary_sensor": {
+      "mixer_pump1": { "name": "Mixer 1 pump" },
+      "boiler_pump": { "name": "Boiler pump" }
+    },
     "sensor": {
-      "boiler_power": { "name": "Boiler poweer stringas cia" },
+      "boiler_power": { "name": "Boiler power" },
       "temp_external_sensor": { "name": "Outside temperature" },
       "temp_feeder": {"name": "Feeder temperature"},
-      "fuel_fevel": { "name": "fuel Level" },
-      "ther_mostat": { "name": "thermostat" },
-      "lambda_status": { "name": "lambda Status" },
-      "lambda_set": { "name": "lambda Set" },
-      "lambda_level": { "name": "lambda Level" },
-      "signal": { "name": "signaliukas" },
-      "temp_c": { "name": "tempCOukas" },
-      "temp_cwu": { "name": "tempCWUiukas" },
-      "temp_upper_buffer": { "name": "tempUpper Buffer" },
-      "temp_lower_buffer": { "name": "tempLower Buffer" },
-      "temp_flue_gas": { "name": "temp Flue Gas" },
-      "mixer_temp1": { "name": "mixer Temp1" },
-      "mixer_set_temp1": { "name": "mixer SetT emp1" },
-      "mode": { "name": "Modukas" },
-      "fan_power": { "name": "fanPoweriukas" },
-      "temp_co_set": { "name": "tempCOSetukas" }
-}
+      "fuel_level": { "name": "Fuel level" },
+      "thermostat": { "name": "Thermostat" },
+      "lambda_status": { "name": "Lambda status" },
+      "lambda_set": { "name": "Lambda set" },
+      "lambda_level": { "name": "Lambda level" },
+      "signal": { "name": "Signal quality" },
+      "temp_co": { "name": "Heating temperature" },
+      "temp_cwu": { "name": "Water heater temperature" },
+      "temp_upper_buffer": { "name": "Upper buffer temperature" },
+      "temp_lower_buffer": { "name": "Lower buffer temperature" },
+      "temp_flue_gas": { "name": "Flue gas temperature" },
+      "mixer_temp1": { "name": "Mixer 1 temperature" },
+      "mixer_set_temp1": { "name": "Mixer target temperature" },
+      "mode": { "name": "Boiler mode" },
+      "fan_power": { "name": "Fan power" },
+      "temp_co_set": { "name": "Heating target temperature" }
+    }
   }
 }
-

--- a/custom_components/econet300/translations/en.json
+++ b/custom_components/econet300/translations/en.json
@@ -1,44 +1,48 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Device is already configured"
-        },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "host": "Host",
-                    "password": "Password",
-                    "username": "Username"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host",
+          "username": "Username",
+          "password": "Password"
         }
+      }
     },
-    "entity":{
-        "sensor": {
-            "boiler_power": { "name": "Boiler katilo galia" },
-            "temp_external_sensor": { "name": "Outside temperature" },
-            "temp_feeder": {"name": "Feeder temperature"},
-            "fuel_fevel": { "name": "fuel Level" },
-            "ther_mostat": { "name": "thermostat" },
-            "lambda_status": { "name": "lambda Status" },
-            "lambda_set": { "name": "lambda Set" },
-            "lambda_level": { "name": "lambda Level" },
-            "signal": { "name": "signaliukas" },
-            "temp_co": { "name": "tempCOukas" },
-            "temp_cwu": { "name": "tempCWUiukas" },
-            "temp_upper_buffer": { "name": "tempUpper Buffer" },
-            "temp_lower_buffer": { "name": "tempLower Buffer" },
-            "temp_flue_gas": { "name": "temp Flue Gas" },
-            "mixer_temp1": { "name": "mixer Temp1" },
-            "mixer_set_temp1": { "name": "mixer SetT emp1" },
-            "mode": { "name": "Modukas" },
-            "fan_power": { "name": "fanPoweriukas" },
-            "temp_co_set": { "name": "tempCOSetukas" }
-        }
+    "error": {
+        "cannot_connect": "Failed to connect",
+        "invalid_auth": "Invalid authentication",
+        "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Device is already configured"
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "mixer_pump1": { "name": "Mixer 1 pump" },
+      "boiler_pump": { "name": "Boiler pump" }
+    },
+    "sensor": {
+      "boiler_power": { "name": "Boiler power" },
+      "temp_external_sensor": { "name": "Outside temperature" },
+      "temp_feeder": {"name": "Feeder temperature"},
+      "fuel_level": { "name": "Fuel level" },
+      "thermostat": { "name": "Thermostat" },
+      "lambda_status": { "name": "Lambda status" },
+      "lambda_set": { "name": "Lambda set" },
+      "lambda_level": { "name": "Lambda level" },
+      "signal": { "name": "Signal quality" },
+      "temp_co": { "name": "Heating temperature" },
+      "temp_cwu": { "name": "Water heater temperature" },
+      "temp_upper_buffer": { "name": "Upper buffer temperature" },
+      "temp_lower_buffer": { "name": "Lower buffer temperature" },
+      "temp_flue_gas": { "name": "Flue gas temperature" },
+      "mixer_temp1": { "name": "Mixer 1 temperature" },
+      "mixer_set_temp1": { "name": "Mixer target temperature" },
+      "mode": { "name": "Boiler mode" },
+      "fan_power": { "name": "Fan power" },
+      "temp_co_set": { "name": "Heating target temperature" }
+    }
+  }
 }

--- a/custom_components/econet300/translations/pl.json
+++ b/custom_components/econet300/translations/pl.json
@@ -1,21 +1,48 @@
 {
-    "config": {
-        "abort": {
-            "already_configured": "Urządzenie zostało już skonfigutowane"
-        },
-        "error": {
-            "cannot_connect": "Błąd połączenia",
-            "invalid_auth": "Błąd autoryzacji",
-            "unknown": "Niespodziewany błąd"
-        },
-        "step": {
-            "user": {
-                "data": {
-                    "host": "Host",
-                    "password": "Hasło",
-                    "username": "Nazwa użytkownika"
-                }
-            }
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "Host",
+          "username": "Hasło",
+          "password": "Nazwa użytkownika"
         }
+      }
+    },
+    "error": {
+        "cannot_connect": "Błąd połączenia",
+        "invalid_auth": "Błąd autoryzacji",
+        "unknown": "Niespodziewany błąd"
+    },
+    "abort": {
+      "already_configured": "Urządzenie zostało już skonfigutowane"
     }
+  },
+  "entity":{
+    "binary_sensor": {
+      "mixer_pump1": { "name": "Mixer 1 pump" },
+      "boiler_pump": { "name": "Boiler pump" }
+    },
+    "sensor": {
+      "boiler_power": { "name": "Boiler katilo galia" },
+      "temp_external_sensor": { "name": "Outside temperature" },
+      "temp_feeder": {"name": "Feeder temperature"},
+      "fuel_level": { "name": "Fuel level" },
+      "thermostat": { "name": "Thermostat" },
+      "lambda_status": { "name": "Lambda status" },
+      "lambda_set": { "name": "Lambda set" },
+      "lambda_level": { "name": "Lambda level" },
+      "signal": { "name": "Signal quality" },
+      "temp_co": { "name": "Heating temperature" },
+      "temp_cwu": { "name": "Water heater temperature" },
+      "temp_upper_buffer": { "name": "Upper buffer temperature" },
+      "temp_lower_buffer": { "name": "Lower buffer temperature" },
+      "temp_flue_gas": { "name": "Flue gas temperature" },
+      "mixer_temp1": { "name": "Mixer 1 temperature" },
+      "mixer_set_temp1": { "name": "Mixer target temperature" },
+      "mode": { "name": "Boiler mode" },
+      "fan_power": { "name": "Fan power" },
+      "temp_co_set": { "name": "Heating target temperature" }
+    }
+  }
 }


### PR DESCRIPTION
Try this. Translations should work fine now.
Don't forget to fill `pl.json` yourself, since I don't know Polish sadly :(

- Fixed typos in translation keys.
- Removed unnecessary name property.
- Add translation keys for the binary sensors.

See: https://developers.home-assistant.io/docs/internationalization/core/#name-of-entities