### PR TITLE
bugfix: Fix adding mixer sensor

### DIFF
--- a/custom_components/econet300/binary_sensor.py
+++ b/custom_components/econet300/binary_sensor.py
@@ -183,10 +183,10 @@ def create_mixer_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
     entities = []
 
     for i in range(1, AVAILABLE_NUMBER_OF_MIXERS + 1):
-        availaimility_mixer_key = f"mixerTemp{i}"
-        if can_add_mixer(availaimility_mixer_key, coordinator):
+        availability_mixer_key = f"mixerTemp{i}"
+        if can_add_mixer(availability_mixer_key, coordinator):
             description = EconetBinarySensorEntityDescription(
-                availability_key=availaimility_mixer_key,
+                availability_key=availability_mixer_key,
                 key=f"mixerPumpWorks{i}",
                 name=f"Mixer {i}",
                 icon="mdi:pump",
@@ -197,7 +197,7 @@ def create_mixer_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
         else:
             _LOGGER.debug(
                 "Availability key: %s does not exist, entity will not be added",
-                description.key,
+                availability_mixer_key,
             )
 
     return entities


### PR DESCRIPTION
It was not possible to create all binary sensors due to the coding error. 

Error from HA:

```
Logger: homeassistant.components.binary_sensor
Source: helpers/entity_platform.py:360
Integration: Binary sensor (documentation, issues)
First occurred: 9:20:38 AM (1 occurrences)
Last logged: 9:20:38 AM

Error while setting up econet300 platform for binary_sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 360, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/econet300/binary_sensor.py", line 223, in async_setup_entry
    entities = entities + create_mixer_sensors(coordinator, api)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/econet300/binary_sensor.py", line 205, in create_mixer_sensors
    description.key,
    ^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'description' where it is not associated with a value
```