### PR TITLE
add ServoMix1 HA states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,5 +84,17 @@ Thank for @pblxptr add new code line from him
 - Separated entity by types for better management
 - Moved Mixer sensors to the Mixer sensor group and added icons
 
+## [v1.0.3-beta] 2024-10-15
+### Added
+- Introduced new `ServoMixer1` state handling with predefined Home Assistant states (`STATE_OFF`, `STATE_CLOSING`, `STATE_OPENING`).
+- Added logging for non-numeric values in sensor processing to improve debugging.
+
+### Changed
+- Updated `ENTITY_VALUE_PROCESSOR` to use predefined Home Assistant states for `ServoMixer1`.
+- Improved error handling in `create_controller_sensors` to skip non-numeric values and log warnings.
+
+### Fixed
+- Fixed `ValueError` caused by non-numeric values in sensor state processing.
+- Resolved Mypy type incompatibility issue in `STATE_CLASS_MAP` by removing the `servoMixer1` entry with `None` value.
 
 

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -9,9 +9,16 @@ from homeassistant.const import (
     STATE_CLOSING,
     STATE_OFF,
     STATE_OPENING,
+    STATE_UNKNOWN,
     EntityCategory,
     UnitOfTemperature,
 )
+
+SERVO_MIXER_VALVE_HA_STATE: dict[int, str] = {
+    0: STATE_OFF,
+    1: STATE_CLOSING,
+    2: STATE_OPENING,
+}
 
 # Constant for the econet Integration integration
 DOMAIN = "econet300"
@@ -47,7 +54,7 @@ API_RM_CURRENT_DATA_PARAMS_URI = "rmCurrentDataParams"
 ## Mapunits for params data map API_RM_CURRENT_DATA_PARAMS_URI
 API_RM_PARAMSUNITSNAMES_URI = "rmParamsUnitsNames"
 
-## Boiler staus keys map
+# Boiler staus keys map
 # boiler mode names from  endpoint http://LocalIP/econet/rmParamsEnums?
 OPERATION_MODE_NAMES = {
     0: "off",
@@ -89,14 +96,14 @@ EDITABLE_PARAMS_MAPPING_TABLE = {
 }
 
 ###################################
-######## NUMBER of AVAILABLE MIXERS
+#    NUMBER of AVAILABLE MIXERS
 ###################################
 AVAILABLE_NUMBER_OF_MIXERS = 6
 MIXER_AVAILABILITY_KEY = "mixerTemp"
 MIXER_KEY = "mixerPumpWorks"
 
 #######################
-######## REG PARAM MAPS
+#    REG PARAM MAPS
 #######################
 SENSOR_MAP = {
     "26": "tempFeeder",
@@ -237,10 +244,11 @@ ENTITY_NUMBER_SENSOR_DEVICE_CLASS_MAP = {
     "tempCWUSet": NumberDeviceClass.TEMPERATURE,
 }
 
-#############################
-#      BINARY SENSORS
-#############################
+
 ENTITY_BINARY_DEVICE_CLASS_MAP = {
+    #############################
+    #      BINARY SENSORS
+    #############################
     "lighter": BinarySensorDeviceClass.RUNNING,
     "weatherControl": BinarySensorDeviceClass.RUNNING,
     "unseal": BinarySensorDeviceClass.RUNNING,
@@ -327,14 +335,7 @@ ENTITY_VALUE_PROCESSOR = {
     ),
     "status_wifi": lambda x: "Connected" if x == 1 else "Disconnected",
     "main_server": lambda x: "Server available" if x == 1 else "Server not available",
-    ## TODO check HA status maybe there are somthink STATE_OFF, OPENING CLOSING
-    # "servoMixer1": (lambda x: {0: "Off", 1: "closing", 2: "opening"}.get(x, "unknown")),
-}
-
-SERVO_MIXER_VALVE_HA_STATE: dict[int, str] = {
-    0: STATE_OFF,
-    1: STATE_CLOSING,
-    2: STATE_OPENING,
+    "servoMixer1": lambda x: SERVO_MIXER_VALVE_HA_STATE.get(x, STATE_UNKNOWN),
 }
 
 

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -6,6 +6,9 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    STATE_CLOSING,
+    STATE_OFF,
+    STATE_OPENING,
     EntityCategory,
     UnitOfTemperature,
 )
@@ -325,8 +328,15 @@ ENTITY_VALUE_PROCESSOR = {
     "status_wifi": lambda x: "Connected" if x == 1 else "Disconnected",
     "main_server": lambda x: "Server available" if x == 1 else "Server not available",
     ## TODO check HA status maybe there are somthink STATE_OFF, OPENING CLOSING
-    "servoMixer1": (lambda x: {0: "Off", 1: "closing", 2: "opening"}.get(x, "unknown")),
+    # "servoMixer1": (lambda x: {0: "Off", 1: "closing", 2: "opening"}.get(x, "unknown")),
 }
+
+SERVO_MIXER_VALVE_HA_STATE: dict[int, str] = {
+    0: STATE_OFF,
+    1: STATE_CLOSING,
+    2: STATE_OPENING,
+}
+
 
 ENTITY_CATEGORY = {
     "signal": EntityCategory.DIAGNOSTIC,

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -231,7 +231,7 @@ ENTITY_SENSOR_DEVICE_CLASS_MAP: dict[str, SensorDeviceClass | None] = {
     "protocolType": None,
     "controllerID": None,
     "valveMixer1": None,
-    "servoMixer1": None,
+    "servoMixer1": SensorDeviceClass.ENUM,
     "Status_wifi": None,
     "main_server": None,
 }
@@ -307,6 +307,8 @@ ENTITY_ICON = {
     "mixerSetTemp": "mdi:thermometer",
     "valveMixer1": "mdi:valve",
     "mixerSetTemp1": "mdi:thermometer-chevron-up",
+    "servoMixer1": "mdi:valve",
+    "mixerTemp1": "mdi:thermometer",
 }
 
 ENTITY_ICON_OFF = {

--- a/custom_components/econet300/manifest.json
+++ b/custom_components/econet300/manifest.json
@@ -13,6 +13,6 @@
   "issue_tracker": "https://github.com/jontofront/ecoNET-300-Home-Assistant-Integration/issues",
   "requirements": [],
   "ssdp": [],
-  "version": "v1.0.2-beta",
+  "version": "v1.0.3-beta",
   "zeroconf": []
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 
 [tool.poetry]
 name = "ecoNET-300-Home-Assistant-Integration"
-version = "v1.0.2-beta"
+version = "v1.0.3-beta"
 description = "ecoNET300 Home Assistant integration"
 authors = ["Jon <jontofront@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
### Added
- Introduced new `ServoMixer1` state handling with predefined Home Assistant states (`STATE_OFF`, `STATE_CLOSING`, `STATE_OPENING`).
- Added logging for non-numeric values in sensor processing to improve debugging.

### Changed
- Updated `ENTITY_VALUE_PROCESSOR` to use predefined Home Assistant states for `ServoMixer1`.
- Improved error handling in `create_controller_sensors` to skip non-numeric values and log warnings.

### Fixed
- Fixed `ValueError` caused by non-numeric values in sensor state processing.
- Resolved Mypy type incompatibility issue in `STATE_CLASS_MAP` by removing the `servoMixer1` entry with `None` value.