### PR TITLE
80 bug data for key data does not exist

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,4 +9,12 @@
     "[json]": {
         "editor.defaultFormatter": "vscode.json-language-features"
     },
+    "cSpell.words": [
+        "aiohttp",
+        "econet",
+        "hass",
+        "homeassistant",
+        "MILLIWATT",
+        "PARAMSUNITSNAMES"
+    ],
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
         "aiohttp",
         "clientsession",
         "econet",
+        "ecoster",
         "hass",
         "homeassistant",
         "MILLIWATT",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
     },
     "cSpell.words": [
         "aiohttp",
+        "clientsession",
         "econet",
         "hass",
         "homeassistant",

--- a/custom_components/econet300/__init__.py
+++ b/custom_components/econet300/__init__.py
@@ -12,7 +12,7 @@ from .common import AuthError, EconetDataCoordinator
 from .const import DOMAIN, SERVICE_API, SERVICE_COORDINATOR
 from .mem_cache import MemCache
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.NUMBER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/econet300/__init__.py
+++ b/custom_components/econet300/__init__.py
@@ -12,7 +12,7 @@ from .common import AuthError, EconetDataCoordinator
 from .const import DOMAIN, SERVICE_API, SERVICE_COORDINATOR
 from .mem_cache import MemCache
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.NUMBER]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/econet300/__init__.py
+++ b/custom_components/econet300/__init__.py
@@ -12,7 +12,7 @@ from .common import AuthError, EconetDataCoordinator
 from .const import DOMAIN, SERVICE_API, SERVICE_COORDINATOR
 from .mem_cache import MemCache
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.NUMBER]
+PLATFORMS: list[Platform] = [Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/econet300/__init__.py
+++ b/custom_components/econet300/__init__.py
@@ -12,7 +12,7 @@ from .common import AuthError, EconetDataCoordinator
 from .const import DOMAIN, SERVICE_API, SERVICE_COORDINATOR
 from .mem_cache import MemCache
 
-PLATFORMS: list[Platform] = [Platform.SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -255,7 +255,7 @@ class Econet300Api:
 
         return True
 
-    async def fetch_rm_current_data_params_edits(self, param: str):
+    async def get_param_limits(self, param: str):
         """Fetch and return the limits for a particular parameter from the Econet 300 API, using a cache for efficient retrieval if available."""
         if not self._cache.exists(API_EDITABLE_PARAMS_LIMITS_DATA):
             limits = await self._fetch_reg_key(
@@ -281,6 +281,8 @@ class Econet300Api:
             return None
 
         curr_limits = limits[param]
+        _LOGGER.debug("Limits '%s'", limits)
+        _LOGGER.debug("Limits for edit param '%s': %s", param, curr_limits)
         return Limits(curr_limits["min"], curr_limits["max"])
 
     async def fetch_reg_params_data(self) -> dict[str, Any]:
@@ -295,6 +297,16 @@ class Econet300Api:
         else:
             _LOGGER.debug("Fetched regParamsData: %s", regParamsData)
             return regParamsData
+
+    async def fetch_param_edit_data(self):
+        """Fetch and return the limits for a particular parameter from the Econet 300 API, using a cache for efficient retrieval if available."""  # Pakeisti
+        if not self._cache.exists(API_EDITABLE_PARAMS_LIMITS_DATA):
+            limits = await self._fetch_reg_key(
+                API_EDITABLE_PARAMS_LIMITS_URI, API_EDITABLE_PARAMS_LIMITS_DATA
+            )
+            self._cache.set(API_EDITABLE_PARAMS_LIMITS_DATA, limits)
+
+        return self._cache.get(API_EDITABLE_PARAMS_LIMITS_DATA)
 
     async def _fetch_reg_key(self, reg, data_key: str | None = None):
         """Fetch a key from the json-encoded data returned by the API for a given registry If key is None, then return whole data."""

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -94,12 +94,13 @@ class EconetClient:
             f"{self._host}/econet/rmCurrNewParam?newParamKey={key}&newParamValue={value}"
         )
 
+    ##Check this method for possible changes its fetching data from regParams ???
     async def fetch_sys_params(self, reg: str):
         """Call for getting api param from IP/econet/sysParams."""
         _LOGGER.debug(
             "fetch_sys_params called: Fetching parameters for registry '%s' from host '%s'",
-            reg,
             self._host,
+            reg,
         )
         data = await self._get(f"{self._host}/econet/{reg}")
         _LOGGER.debug("Fetched data for registry '%s': %s", reg, data)

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -94,10 +94,10 @@ class EconetClient:
             f"{self._host}/econet/rmCurrNewParam?newParamKey={key}&newParamValue={value}"
         )
 
-    async def get_params(self, reg: str):
+    async def fetch_sys_params(self, reg: str):
         """Call for getting api param."""
         _LOGGER.debug(
-            "get_params called: Fetching parameters for registry '%s' from host '%s'",
+            "fetch_sys_params called: Fetching parameters for registry '%s' from host '%s'",
             reg,
             self._host,
         )
@@ -207,7 +207,7 @@ class Econet300Api:
 
     async def init(self):
         """Econet300 Api initilization."""
-        sys_params = await self._client.get_params(API_SYS_PARAMS_URI)
+        sys_params = await self._client.fetch_sys_params(API_SYS_PARAMS_URI)
 
         if API_SYS_PARAMS_PARAM_UID not in sys_params:
             _LOGGER.warning(
@@ -289,7 +289,7 @@ class Econet300Api:
         curr_limits = limits[param]
         return Limits(curr_limits["min"], curr_limits["max"])
 
-    async def fetch_data(self) -> dict[str, Any]:
+    async def fetch_reg_params_data(self) -> dict[str, Any]:
         """Fetch data from econet/regParamsData."""
         try:
             regParamsData = await self._fetch_reg_key(
@@ -304,7 +304,7 @@ class Econet300Api:
 
     async def _fetch_reg_key(self, reg, data_key: str | None = None):
         """Fetch a key from the json-encoded data returned by the API for a given registry If key is None, then return whole data."""
-        data = await self._client.get_params(reg)
+        data = await self._client.fetch_sys_params(reg)
 
         if data is None:
             raise DataError(f"Data fetched by API for reg: {reg} is None")
@@ -318,6 +318,9 @@ class Econet300Api:
 
         return data[data_key]
 
+    async def fetch_sys_params(self) -> dict[str, Any]:
+        return await self._client.fetch_sys_params(API_SYS_PARAMS_URI)
+
     async def fetch_reg_params(self) -> dict[str, Any]:
         """Fetch and return the regParam data from ip/econet/regParams endpoint."""
         _LOGGER.info("Calling fetch_reg_params method")
@@ -325,23 +328,11 @@ class Econet300Api:
             API_REG_PARAMS_URI, API_REG_PARAMS_PARAM_DATA
         )
         _LOGGER.debug("Fetched regParams data: %s", regParams)
-
-        if API_REG_PARAMS_PARAM_DATA in regParams:
-            _LOGGER.info(
-                "Response contains expected keys. API_REG_PARAMS_PARAM_DATA: %s",
-                regParams[API_REG_PARAMS_PARAM_DATA],
-            )
-        else:
-            _LOGGER.warning(
-                "Response does not contain expected keys. API_REG_PARAMS_PARAM_DATA is missing."
-            )
-            _LOGGER.debug("Full response data: %s", regParams)
-
         return regParams
 
     async def _fetch_reg_names(self, reg, data_key_key_name: str | None = None):
         """Fetch a key from the json-encoded data returned by the API for a given registry If key is None, then return whole data."""
-        data = await self._client.get_params(reg)
+        data = await self._client.fetch_sys_params(reg)
 
         if data is None:
             raise DataError(f"Data fetched by API for reg: {reg} is None")

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -113,11 +113,7 @@ class EconetClient:
         while attempt <= max_attempts:
             try:
                 _LOGGER.debug("Fetching data from URL: %s (Attempt %d)", url, attempt)
-                _LOGGER.debug(
-                    "Using model_id: %s, sw_revision: %s",
-                    self._model_id,
-                    self._sw_revision,
-                )
+
                 async with await self._session.get(
                     url, auth=self._auth, timeout=10
                 ) as resp:

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -255,7 +255,7 @@ class Econet300Api:
 
         return True
 
-    async def get_param_limits(self, param: str):
+    async def fetch_rm_current_data_params_edits(self, param: str):
         """Fetch and return the limits for a particular parameter from the Econet 300 API, using a cache for efficient retrieval if available."""
         if not self._cache.exists(API_EDITABLE_PARAMS_LIMITS_DATA):
             limits = await self._fetch_reg_key(

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -290,12 +290,17 @@ class Econet300Api:
         return Limits(curr_limits["min"], curr_limits["max"])
 
     async def fetch_data(self) -> dict[str, Any]:
-        """Fetch data from regParamsData."""
-        regParamsData = await self._fetch_reg_key(
-            API_REG_PARAMS_DATA_URI, API_REG_PARAMS_DATA_PARAM_DATA
-        )
-        _LOGGER.debug("Fetched regParamsData: %s", regParamsData)
-        return regParamsData
+        """Fetch data from econet/regParamsData."""
+        try:
+            regParamsData = await self._fetch_reg_key(
+                API_REG_PARAMS_DATA_URI, API_REG_PARAMS_DATA_PARAM_DATA
+            )
+        except DataError as e:
+            _LOGGER.error("Error fetching regParamsData: %s", e)
+            return {}
+        else:
+            _LOGGER.debug("Fetched regParamsData: %s", regParamsData)
+            return regParamsData
 
     async def _fetch_reg_key(self, reg, data_key: str | None = None):
         """Fetch a key from the json-encoded data returned by the API for a given registry If key is None, then return whole data."""

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -15,6 +15,8 @@ from .const import (
     API_EDITABLE_PARAMS_LIMITS_URI,
     API_REG_PARAMS_DATA_PARAM_DATA,
     API_REG_PARAMS_DATA_URI,
+    API_REG_PARAMS_PARAM_DATA,
+    API_REG_PARAMS_URI,
     API_SYS_PARAMS_PARAM_HW_VER,
     API_SYS_PARAMS_PARAM_MODEL_ID,
     API_SYS_PARAMS_PARAM_SW_REV,
@@ -322,6 +324,43 @@ class Econet300Api:
             raise DataError(f"Data for key: {data_key} does not exist")
 
         return data[data_key]
+
+    async def fetch_reg_params(self) -> dict[str, Any]:
+        """Fetch and return the regParam data from ip/econet/regParams endpoint."""
+        _LOGGER.info("Calling fetch_reg_params method")
+        regParams = await self._fetch_reg_names(
+            API_REG_PARAMS_URI, API_REG_PARAMS_PARAM_DATA
+        )
+        _LOGGER.debug("Fetched regParams data: %s", regParams)
+
+        if API_REG_PARAMS_PARAM_DATA in regParams:
+            _LOGGER.info(
+                "Response contains expected keys. API_REG_PARAMS_PARAM_DATA: %s",
+                regParams[API_REG_PARAMS_PARAM_DATA],
+            )
+        else:
+            _LOGGER.warning(
+                "Response does not contain expected keys. API_REG_PARAMS_PARAM_DATA is missing."
+            )
+            _LOGGER.debug("Full response data: %s", regParams)
+
+        return regParams
+
+    async def _fetch_reg_names(self, reg, data_key_key_name: str | None = None):
+        """Fetch a key from the json-encoded data returned by the API for a given registry If key is None, then return whole data."""
+        data = await self._client.get_params(reg)
+
+        if data is None:
+            raise DataError(f"Data fetched by API for reg: {reg} is None")
+
+        if data_key_key_name is None:
+            return data
+
+        if data_key_key_name not in data:
+            _LOGGER.debug(data)
+            raise DataError(f"Data for key: {data_key_key_name} does not exist")
+
+        return data[data_key_key_name]
 
 
 async def make_api(hass: HomeAssistant, cache: MemCache, data: dict):

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -297,18 +297,6 @@ class Econet300Api:
         _LOGGER.debug("Fetched regParamsData: %s", regParamsData)
         return regParamsData
 
-    async def get_alarms(self):
-        """Fetch and return the alarms data from sysParams."""
-        _LOGGER.info("Calling get_alarms method")
-        sys_params = await self._client.get_params(API_SYS_PARAMS_URI)
-        _LOGGER.debug("Fetched from sysParams alarms: %s", sys_params)
-
-        if "alarms" not in sys_params:
-            _LOGGER.warning("Alarms not found in system parameters")
-            return None
-        _LOGGER.debug("Fetched alarms: %s", sys_params["alarms"])
-        return sys_params["alarms"]
-
     async def _fetch_reg_key(self, reg, data_key: str | None = None):
         """Fetch a key from the json-encoded data returned by the API for a given registry If key is None, then return whole data."""
         data = await self._client.get_params(reg)

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -1,4 +1,4 @@
-"""Econet300 API class class describint methods of getting and setting data."""
+"""Econet300 API class describing methods of getting and setting data."""
 
 import asyncio
 from http import HTTPStatus
@@ -38,7 +38,7 @@ def map_param(param_name):
 
 
 class Limits:
-    """Class difining entity value set limits."""
+    """Class defining entity value set limits."""
 
     def __init__(self, min_v: int | None, max_v: int | None):
         """Construct the necessary attributes for the Limits object."""
@@ -67,7 +67,7 @@ class EconetClient:
     def __init__(
         self, host: str, username: str, password: str, session: ClientSession
     ) -> None:
-        """Initializethe EconetClient."""
+        """Initialize the EconetClient."""
 
         proto = ["http://", "https://"]
 
@@ -163,15 +163,6 @@ class Econet300Api:
         self._sw_revision = "default-sw-revision"
         self._hw_version = "default-hw-version"
 
-        _LOGGER.debug("Econet300Api initialized with client: %s", client)
-        _LOGGER.debug("Econet300Api initialized with cache: %s", cache)
-        _LOGGER.debug("Econet300Api initialized with uid: %s", self._uid)
-        _LOGGER.debug("Econet300Api initialized with model_id: %s", self._model_id)
-        _LOGGER.debug(
-            "Econet300Api initialized with sw_revision: %s", self._sw_revision
-        )
-        _LOGGER.debug("Econet300Api initialized with hw_version: %s", self._hw_version)
-
     @classmethod
     async def create(cls, client: EconetClient, cache: MemCache):
         """Create and return initial object."""
@@ -206,7 +197,7 @@ class Econet300Api:
         return self._hw_version
 
     async def init(self):
-        """Econet300 Api initilization."""
+        """Econet300 Api initialization."""
         sys_params = await self._client.fetch_sys_params(API_SYS_PARAMS_URI)
 
         if API_SYS_PARAMS_PARAM_UID not in sys_params:
@@ -319,10 +310,11 @@ class Econet300Api:
         return data[data_key]
 
     async def fetch_sys_params(self) -> dict[str, Any]:
+        """Fetch and return the regParam data from ip/econet/sysParams endpoint."""
         return await self._client.fetch_sys_params(API_SYS_PARAMS_URI)
 
     async def fetch_reg_params(self) -> dict[str, Any]:
-        """Fetch and return the regParam data from ip/econet/regParams endpoint."""
+        """Fetch and return the regParams data from ip/econet/regParams endpoint."""
         _LOGGER.info("Calling fetch_reg_params method")
         regParams = await self._fetch_reg_names(
             API_REG_PARAMS_URI, API_REG_PARAMS_PARAM_DATA

--- a/custom_components/econet300/binary_sensor.py
+++ b/custom_components/econet300/binary_sensor.py
@@ -91,7 +91,7 @@ def create_binary_entity_description(key: str) -> EconetBinarySensorEntityDescri
 def create_binary_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
     """Create binary sensors."""
     entities: list[EconetBinarySensor] = []
-    coordinator_data = coordinator.data
+    coordinator_data = coordinator.data["sysParams"]
     for data_key in BINARY_SENSOR_MAP:
         _LOGGER.debug("Processing data_key: %s", data_key)
         if data_key in coordinator_data:

--- a/custom_components/econet300/binary_sensor.py
+++ b/custom_components/econet300/binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .common import Econet300Api, EconetDataCoordinator
 from .common_functions import camel_to_snake
 from .const import (
-    BINARY_SENSOR_MAP,
+    BINARY_SENSOR_MAP_KEY,
     DOMAIN,
     ENTITY_BINARY_DEVICE_CLASS_MAP,
     ENTITY_ICON,
@@ -61,6 +61,11 @@ class EconetBinarySensor(EconetEntity, BinarySensorEntity):
         """Sync state."""
         _LOGGER.debug("EconetBinarySensor _sync_state: %s", value)
         self._attr_is_on = value
+        _LOGGER.debug(
+            "Updated Binary sensor _attr_is_on for %s: %s",
+            self.entity_description.key,
+            self._attr_is_on,
+        )
         self.async_write_ha_state()
 
     @property
@@ -75,14 +80,13 @@ class EconetBinarySensor(EconetEntity, BinarySensorEntity):
 
 def create_binary_entity_description(key: str) -> EconetBinarySensorEntityDescription:
     """Create Econet300 binary entity description."""
-    map_key = BINARY_SENSOR_MAP.get(key, key)
-    _LOGGER.debug("create_binary_entity_description: %s", map_key)
+    _LOGGER.debug("create_binary_entity_description: %s", key)
     entity_description = EconetBinarySensorEntityDescription(
         key=key,
-        translation_key=camel_to_snake(map_key),
-        device_class=ENTITY_BINARY_DEVICE_CLASS_MAP.get(map_key, None),
-        icon=ENTITY_ICON.get(map_key, None),
-        icon_off=ENTITY_ICON_OFF.get(map_key, None),
+        translation_key=camel_to_snake(key),
+        device_class=ENTITY_BINARY_DEVICE_CLASS_MAP.get(key, None),
+        icon=ENTITY_ICON.get(key, None),
+        icon_off=ENTITY_ICON_OFF.get(key, None),
     )
     _LOGGER.debug("create_binary_entity_description: %s", entity_description)
     return entity_description
@@ -91,9 +95,9 @@ def create_binary_entity_description(key: str) -> EconetBinarySensorEntityDescri
 def create_binary_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
     """Create binary sensors."""
     entities: list[EconetBinarySensor] = []
-    coordinator_data = coordinator.data["sysParams"]
-    for data_key in BINARY_SENSOR_MAP:
-        _LOGGER.debug("Processing data_key: %s", data_key)
+    coordinator_data = coordinator.data["regParams"]
+    for data_key in BINARY_SENSOR_MAP_KEY["_default"]:
+        _LOGGER.debug("Processing binary sensor data_key: %s", data_key)
         if data_key in coordinator_data:
             entity = EconetBinarySensor(
                 create_binary_entity_description(data_key), coordinator, api

--- a/custom_components/econet300/common.py
+++ b/custom_components/econet300/common.py
@@ -28,13 +28,13 @@ class EconetDataCoordinator(DataUpdateCoordinator):
         self._api = api
 
     def has_sys_data(self, key: str):
-        """Check if datakey is present in sysParams."""
+        """Check if data key is present in sysParams."""
         if self.data is None:
             return False
         return key in self.data["sysParams"]
 
     def has_reg_data(self, key: str):
-        """Check if datakey is present in regParams."""
+        """Check if data key is present in regParams."""
         if self.data is None:
             return False
 

--- a/custom_components/econet300/common.py
+++ b/custom_components/econet300/common.py
@@ -40,6 +40,13 @@ class EconetDataCoordinator(DataUpdateCoordinator):
 
         return key in self.data["regParams"]
 
+    def has_param_edit_data(self, key: str):
+        """Check if ."""
+        if self.data is None:
+            return False
+
+        return key in self.data["paramsEdits"]
+
     async def _async_update_data(self):
         """Fetch data from API endpoint.
 
@@ -62,7 +69,12 @@ class EconetDataCoordinator(DataUpdateCoordinator):
                     "Fetching system parameters for model: %s", self._api.model_id
                 )
                 reg_params = await self._api.fetch_reg_params()
-                return {"sysParams": data, "regParams": reg_params}
+                params_edits = await self._api.fetch_param_edit_data()
+                return {
+                    "sysParams": data,
+                    "regParams": reg_params,
+                    "paramsEdits": params_edits,
+                }
         except AuthError as err:
             raise ConfigEntryAuthFailed from err
         except ApiError as err:

--- a/custom_components/econet300/common.py
+++ b/custom_components/econet300/common.py
@@ -27,14 +27,18 @@ class EconetDataCoordinator(DataUpdateCoordinator):
         )
         self._api = api
 
-    def has_data(self, key: str):
-        """Check if datakey is present in data."""
+    def has_sys_data(self, key: str):
+        """Check if datakey is present in sysParams."""
+        if self.data is None:
+            return False
+        return key in self.data["sysParams"]
+
+    def has_reg_data(self, key: str):
+        """Check if datakey is present in regParams."""
         if self.data is None:
             return False
 
-        has_key = key in self.data["sysParams"] or self.data["regParams"]
-        _LOGGER.debug("has_data: %s=%s", key, has_key)
-        return has_key
+        return key in self.data["regParams"]
 
     async def _async_update_data(self):
         """Fetch data from API endpoint.
@@ -51,8 +55,11 @@ class EconetDataCoordinator(DataUpdateCoordinator):
             async with asyncio.timeout(10):
                 data = (
                     await self._api.fetch_sys_params()
-                    if self._api.model_id == "MAX810P-L TOUCH"
+                    if self._api.model_id == "ecoMAX810P-L TOUCH"
                     else {}
+                )
+                _LOGGER.debug(
+                    "Fetching system parameters for model: %s", self._api.model_id
                 )
                 reg_params = await self._api.fetch_reg_params()
                 return {"sysParams": data, "regParams": reg_params}

--- a/custom_components/econet300/common.py
+++ b/custom_components/econet300/common.py
@@ -1,4 +1,5 @@
 """Common code for econet300 integration."""
+
 import asyncio
 from datetime import timedelta
 import logging
@@ -43,7 +44,9 @@ class EconetDataCoordinator(DataUpdateCoordinator):
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
             async with asyncio.timeout(10):
-                return await self._api.fetch_data()
+                data = await self._api.fetch_data()
+                reg_params = await self._api.fetch_reg_params()
+                return {"sysParams": data, "regParams": reg_params}
         except AuthError as err:
             raise ConfigEntryAuthFailed from err
         except ApiError as err:

--- a/custom_components/econet300/common.py
+++ b/custom_components/econet300/common.py
@@ -49,7 +49,11 @@ class EconetDataCoordinator(DataUpdateCoordinator):
             # Note: asyncio.TimeoutError and aiohttp.ClientError are already
             # handled by the data update coordinator.
             async with asyncio.timeout(10):
-                data = await self._api.fetch_data()
+                data = (
+                    await self._api.fetch_sys_params()
+                    if self._api.model_id == "MAX810P-L TOUCH"
+                    else {}
+                )
                 reg_params = await self._api.fetch_reg_params()
                 return {"sysParams": data, "regParams": reg_params}
         except AuthError as err:

--- a/custom_components/econet300/common.py
+++ b/custom_components/econet300/common.py
@@ -29,7 +29,12 @@ class EconetDataCoordinator(DataUpdateCoordinator):
 
     def has_data(self, key: str):
         """Check if datakey is present in data."""
-        return key in self.data
+        if self.data is None:
+            return False
+
+        has_key = key in self.data["sysParams"] or self.data["regParams"]
+        _LOGGER.debug("has_data: %s=%s", key, has_key)
+        return has_key
 
     async def _async_update_data(self):
         """Fetch data from API endpoint.

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -8,7 +8,6 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     STATE_CLOSING,
     STATE_OFF,
-    STATE_ON,
     STATE_OPENING,
     STATE_PAUSED,
     STATE_PROBLEM,
@@ -78,12 +77,6 @@ OPERATION_MODE_NAMES = {
     13: "no_transmission",
 }
 
-# add constants to future
-PRODUCT_TYPE = {
-    0: "ECOMAX_850P_TYPE",  # regType 0
-    1: "ECOMAX_850i_TYPE",  # regType 1
-}
-
 ## Editable params limits
 API_EDIT_PARAM_URI = "rmCurrNewParam"
 API_EDITABLE_PARAMS_LIMITS_URI = "rmCurrentDataParamsEdits"
@@ -130,7 +123,6 @@ SENSOR_MAP_KEY = {
         "tempFlueGas",
         "mode",
         "fanPower",
-        "tempCOSet",
         "thermostat",
     },
 }
@@ -307,7 +299,7 @@ ENTITY_BINARY_DEVICE_CLASS_MAP = {
     "lighter": BinarySensorDeviceClass.RUNNING,
     "weatherControl": BinarySensorDeviceClass.RUNNING,
     "unseal": BinarySensorDeviceClass.RUNNING,
-    "thermostat": BinarySensorDeviceClass.RUNNING,
+    #    "thermostat": BinarySensorDeviceClass.RUNNING,
     "pumpCOWorks": BinarySensorDeviceClass.RUNNING,
     "fanWorks": BinarySensorDeviceClass.RUNNING,
     "additionalFeeder": BinarySensorDeviceClass.RUNNING,
@@ -381,13 +373,6 @@ ENTITY_ICON_OFF = {
 
 ENTITY_VALUE_PROCESSOR = {
     "mode": lambda x: OPERATION_MODE_NAMES.get(x, STATE_UNKNOWN),
-    "thermostat": (
-        lambda x: (
-            STATE_ON
-            if str(x).strip() == "true"
-            else (STATE_OFF if str(x).strip() == "false" else None)
-        )
-    ),
     "lambdaStatus": (
         lambda x: (
             "stop"
@@ -453,64 +438,4 @@ PRODUCT_MODEL = {
     "ecoMAX860P2-N TOUCH"
     "ecoMAX860P3-V"
     "ecoSOL 301"
-}
-
-ALARMS_NAMES = {
-    0: "No power",
-    1: "Boiler sensor error",
-    2: "Exceeding the maximum temperature of the boiler",
-    3: "Sensor fault feeder",
-    4: "Exceeding the maximum temperature of the tray",
-    5: "Sensor fault system",
-    6: "Exceeding the maximum flue gas temperature",
-    7: "Firing up the boiler failed",
-    8: "No fuel",
-    9: "Loss of Containment",
-    10: "Pressure sensor failed",
-    11: "Faulty fan ",
-    12: "ID Fan Pressure can not be reached ",
-    13: "Burning off error ",
-    14: "Photocell sensor failed",
-    15: "Linear actuator blocked",
-    16: "Incorrect work parameters",
-    17: "Precaution of condensation ",
-    18: "STB is disabled . Manual reset is needed when TB <65 °C Boiler STB ",
-    19: "Opening the contact STB tray ",
-    20: "Minimum water pressure exceeded",
-    21: "Maximum water pressure exceeded",
-    22: "Fuel feeder locked",
-    23: "Extinguished flame ",
-    24: "Faulty exhaust fan",
-    25: "Error loading external feeder ",
-    26: "Error Sensor solar collector SH ",
-    27: "Error Sensor solar circuit SL ",
-    28: "Sensor fault circuit H1- S",
-    29: "Sensor fault circuit H2 - S",
-    30: "Sensor fault circuit H3 - S",
-    31: "Error weather sensor WS ",
-    32: "HUW sensor error ",
-    33: "Sensor error H0- S",
-    34: "It takes frost protection - heat source are not included ",
-    35: "It takes frost protection - the source of the attached ",
-    36: "Exceeded max. Temperature solar collector ",
-    37: "Exceeded max. Flow temperature of the floor ",
-    38: "Cooling preventive solid fuel boiler ",
-    39: "No communication with ecoLAMBDA ",
-    40: "Lock the primary air damper ",
-    41: "Lock the secondary air damper ",
-    42: "Feeder full",
-    43: "Furnace full",
-    44: "No communication with B module",
-    45: "Cleaning servomotor error",
-    46: "Minimum pressure exceeded",
-    47: "Maximum pressure exceeded",
-    48: "Pressure sensor damage",
-    49: "Maximum main heat source temperature exceeded",
-    50: "Maximum additional heat source temperature exceeded",
-    51: "Solar is OFF - temperature  is too high - wait for temperature drop",
-    52: "Alarm for auger control system malfunction",
-    53: "Clogged auger Alarm",
-    54: "Temperature above maximum for the thermocouple.",
-    55: "Thermocouple wired improperly.",
-    255: "Alarm unknown",
 }

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -127,6 +127,13 @@ SENSOR_MAP_KEY = {
     },
 }
 
+SENSOR_MIXER_KEY = {
+    "1": {
+        "mixerTemp1",
+        "mixerSetTemp1",
+    }
+}
+
 BINARY_SENSOR_MAP_KEY = {
     "_default": {
         "lighter",

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -56,7 +56,7 @@ API_REG_PARAMS_DATA_PARAM_DATA = "data"
 ## Map names for params data in API_REG_PARAMS_DATA_URI
 API_RM_CURRENT_DATA_PARAMS_URI = "rmCurrentDataParams"
 
-## Mapunits for params data map API_RM_CURRENT_DATA_PARAMS_URI
+## Map units for params data map API_RM_CURRENT_DATA_PARAMS_URI
 API_RM_PARAMSUNITSNAMES_URI = "rmParamsUnitsNames"
 
 # Boiler staus keys map
@@ -125,6 +125,7 @@ SENSOR_MAP_KEY = {
         "tempFeeder",
         "tempExternalSensor",
         "fuelLevel",
+        "tempCO",
     },
 }
 
@@ -177,7 +178,7 @@ BINARY_SENSOR_MAP = {
     "117": "thermostat",
     "118": "pumpCOWorks",
     "1536": "fanWorks",
-    "1540": "aditionalFeeder",
+    "1540": "additionalFeeder",
     "1541": "pumpFireplaceWorks",
     "1542": "pumpCWUWorks",
 }
@@ -294,7 +295,7 @@ ENTITY_BINARY_DEVICE_CLASS_MAP = {
     "thermostat": BinarySensorDeviceClass.RUNNING,
     "pumpCOWorks": BinarySensorDeviceClass.RUNNING,
     "fanWorks": BinarySensorDeviceClass.RUNNING,
-    "aditionalFeeder": BinarySensorDeviceClass.RUNNING,
+    "additionalFeeder": BinarySensorDeviceClass.RUNNING,
     "pumpFireplaceWorks": BinarySensorDeviceClass.RUNNING,
     "pumpCWUWorks": BinarySensorDeviceClass.RUNNING,
     "mixerPumpWorks": BinarySensorDeviceClass.RUNNING,
@@ -342,7 +343,7 @@ ENTITY_ICON = {
     "quality": "mdi:signal",
     "pumpCOWorks": "mdi:pump",
     "fanWorks": "mdi:fan",
-    "aditionalFeeder": "mdi:screw-lag",
+    "additionalFeeder": "mdi:screw-lag",
     "pumpFireplaceWorks": "mdi:pump",
     "pumpCWUWorks": "mdi:pump",
     "main_server": "mdi:server",
@@ -358,7 +359,7 @@ ENTITY_ICON = {
 ENTITY_ICON_OFF = {
     "pumpCOWorks": "mdi:pump-off",
     "fanWorks": "mdi:fan-off",
-    "aditionalFeeder": "mdi:screw-lag",
+    "additionalFeeder": "mdi:screw-lag",
     "pumpFireplaceWorks": "mdi:pump-off",
     "pumpCWUWorks": "mdi:pump-off",
 }

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -59,7 +59,7 @@ API_RM_CURRENT_DATA_PARAMS_URI = "rmCurrentDataParams"
 ## Map units for params data map API_RM_CURRENT_DATA_PARAMS_URI
 API_RM_PARAMSUNITSNAMES_URI = "rmParamsUnitsNames"
 
-# Boiler staus keys map
+# Boiler status keys map
 # boiler mode names from  endpoint http://LocalIP/econet/rmParamsEnums?
 OPERATION_MODE_NAMES = {
     0: STATE_OFF,
@@ -123,9 +123,15 @@ SENSOR_MAP_KEY = {
     },
     "_default": {
         "tempFeeder",
-        "tempExternalSensor",
         "fuelLevel",
         "tempCO",
+        "tempCOSet",
+        "tempCWUSet",
+        "tempFlueGas",
+        "mode",
+        "fanPower",
+        "tempCOSet",
+        "tempCWUSet",
     },
 }
 

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -132,9 +132,19 @@ SENSOR_MAP_KEY = {
         "fanPower",
         "tempCOSet",
         "tempCWUSet",
+        "thermostat",
     },
 }
 
+BINARY_SENSOR_MAP_KEY = {
+    "_default": {
+        "lighter",
+        "pumpCOWorks",
+        "fanWorks",
+        "pumpFireplaceWorks",
+        "pumpCWUWorks",
+    },
+}
 
 SENSOR_MAP = {
     "26": "tempFeeder",

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -110,6 +110,25 @@ MIXER_KEY = "mixerPumpWorks"
 #######################
 #    REG PARAM MAPS
 #######################
+
+SENSOR_MAP_KEY = {
+    "ecoster": {
+        "ecoSterTemp1",
+        "ecoSterTemp2",
+    },
+    "lambda": {
+        "lambdaStatus",
+        "lambdaSet",
+        "lambdaLevel",
+    },
+    "_default": {
+        "tempFeeder",
+        "tempExternalSensor",
+        "fuelLevel",
+    },
+}
+
+
 SENSOR_MAP = {
     "26": "tempFeeder",
     "28": "tempExternalSensor",
@@ -409,6 +428,15 @@ ENTITY_VISIBLE = {
 REG_PARAM_VISIBLE_DEFAULT = {
     "tempUpperBuffer": False,
     "tempLowerBuffer": False,
+}
+
+PRODUCT_MODEL = {
+    # Models name which known us connect with ecoNET300
+    "ecoMAX810P-L TOUCH"
+    "SControl MK1"
+    "ecoMAX860P2-N TOUCH"
+    "ecoMAX860P3-V"
+    "ecoSOL 301"
 }
 
 ALARMS_NAMES = {

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -131,7 +131,6 @@ SENSOR_MAP_KEY = {
         "mode",
         "fanPower",
         "tempCOSet",
-        "tempCWUSet",
         "thermostat",
     },
 }

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -79,7 +79,7 @@ class EconetEntity(CoordinatorEntity):
             _LOGGER.error("Coordinator object does not have a 'data' attribute")
             return
 
-        # Check the available keys in both sourcese
+        # Check the available keys in both sources
         sys_keys = sys_params.keys()
         reg_keys = reg_params.keys()
         _LOGGER.debug("Available keys in sysParams: %s", sys_keys)

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -103,8 +103,12 @@ class EconetEntity(CoordinatorEntity):
         # Retrieve the value from sysParams or regParams  or paramsEdits
         value = (
             sys_params.get(expected_key)
-            or reg_params.get(expected_key)
-            or params_edits.get(expected_key)
+            if sys_params.get(expected_key) is not None
+            else (
+                reg_params.get(expected_key)
+                if reg_params.get(expected_key) is not None
+                else params_edits.get(expected_key)
+            )
         )
 
         if value is not None:

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -1,7 +1,6 @@
 """Base econet entity class."""
 
 import logging
-from typing import Any
 
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, EntityDescription
@@ -34,11 +33,6 @@ class EconetEntity(CoordinatorEntity):
     @property
     def unique_id(self) -> str | None:
         """Return the unique_id of the entity."""
-        if not self.api.uid:
-            _LOGGER.error(
-                "API UID is missing for entity: %s", self.entity_description.key
-            )
-            return None
         return f"{self.api.uid}-{self.entity_description.key}"
 
     @property
@@ -55,16 +49,6 @@ class EconetEntity(CoordinatorEntity):
             hw_version=self.api.hw_ver,
         )
 
-    def _get_value(self, expected_key: str) -> Any:
-        """Retrieve the value for the expected key from sysParams or regParams."""
-        sys_params = self.coordinator.data.get("sysParams", {})
-        reg_params = self.coordinator.data.get("regParams", {})
-        if expected_key in sys_params:
-            return sys_params[expected_key]
-        if expected_key in reg_params:
-            return reg_params[expected_key]
-        return None
-
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -72,7 +56,7 @@ class EconetEntity(CoordinatorEntity):
             "Update EconetEntity, entity name: %s", self.entity_description.name
         )
 
-        value = self._get_value(self.entity_description.key)
+        value = self.coordinator.data["sysParams"].get(self.entity_description.key)
         if value is None:
             _LOGGER.debug("Value for key %s is None", self.entity_description.key)
             return
@@ -84,29 +68,47 @@ class EconetEntity(CoordinatorEntity):
         _LOGGER.debug("Added to HASS: %s", self.entity_description)
         _LOGGER.debug("Coordinator: %s", self.coordinator)
 
+        # Retrieve sysParams and regParams data
+        sys_params = self.coordinator.data.get("sysParams", {})
+        reg_params = self.coordinator.data.get("regParams", {})
+        _LOGGER.debug("sysParams: %s", sys_params)
+        _LOGGER.debug("regParams: %s", reg_params)
+
         # Check if the coordinator has a 'data' attributes
         if "data" not in dir(self.coordinator):
             _LOGGER.error("Coordinator object does not have a 'data' attribute")
             return
 
-        # # Check the expected key and retrieve the value entity_description
+        # Check the available keys in both sourcese
+        sys_keys = sys_params.keys()
+        reg_keys = reg_params.keys()
+        _LOGGER.debug("Available keys in sysParams: %s", sys_keys)
+        _LOGGER.debug("Available keys in regParams: %s", reg_keys)
+
+        # Expected key from entity_description
         expected_key = self.entity_description.key
         _LOGGER.debug("Expected key: %s", expected_key)
 
         # Retrieve the value from sysParams or regParams
-        value = self._get_value(expected_key)
-        if value is None:
-            sys_keys = self.coordinator.data.get("sysParams", {}).keys()
-            reg_keys = self.coordinator.data.get("regParams", {}).keys()
+        value = None
+        if expected_key in sys_params:
+            value = sys_params[expected_key]
+            _LOGGER.debug(
+                "Found key '%s' in sysParams with value: %s", expected_key, value
+            )
+        elif expected_key in reg_params:
+            value = reg_params[expected_key]
+            _LOGGER.debug(
+                "Found key '%s' in regParams with value: %s", expected_key, value
+            )
+        else:
             _LOGGER.warning(
                 "Data key: %s was expected to exist but it doesn't. Available sysParams keys: %s, regParams keys: %s",
                 expected_key,
-                list(sys_keys),
-                list(reg_keys),
+                sys_keys,
+                reg_keys,
             )
             return
-
-        _LOGGER.debug("Retrieved value for key %s: %s", expected_key, value)
 
         # Synchronize with HASS
         await super().async_added_to_hass()

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -56,11 +56,10 @@ class EconetEntity(CoordinatorEntity):
             "Update EconetEntity, entity name: %s", self.entity_description.name
         )
 
-        if self.coordinator.data["sysParams"][self.entity_description.key] is None:
+        value = self.coordinator.data["sysParams"].get(self.entity_description.key)
+        if value is None:
+            _LOGGER.debug("Value for key %s is None", self.entity_description.key)
             return
-
-        value = self.coordinator.data["sysParams"][self.entity_description.key]
-
         self._sync_state(value)
 
     async def async_added_to_hass(self):
@@ -77,7 +76,8 @@ class EconetEntity(CoordinatorEntity):
 
         if (
             not self.coordinator.has_sys_data(self.entity_description.key)
-            or self.coordinator.data["sysParams"][self.entity_description.key] is None
+            or self.coordinator.data["sysParams"].get(self.entity_description.key)
+            is None
         ):
             _LOGGER.warning(
                 "Data key: %s was expected to exist but it doesn't",
@@ -90,7 +90,7 @@ class EconetEntity(CoordinatorEntity):
             _LOGGER.debug("Exiting async_added_to_hass method")
             return
 
-        value = self.coordinator.data["sysParams"][self.entity_description.key]
+        value = self.coordinator.data["sysParams"].get(self.entity_description.key)
 
         await super().async_added_to_hass()
         self._sync_state(value)

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class EconetEntity(CoordinatorEntity):
-    """Representes EconetEntity."""
+    """Represents EconetEntity."""
 
     api: Econet300Api
     entity_description: EntityDescription

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -76,7 +76,7 @@ class EconetEntity(CoordinatorEntity):
             return
 
         if (
-            not self.coordinator.has_data(self.entity_description.key)
+            not self.coordinator.has_sys_data(self.entity_description.key)
             or self.coordinator.data["sysParams"][self.entity_description.key] is None
         ):
             _LOGGER.warning(

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -59,7 +59,7 @@ class EconetEntity(CoordinatorEntity):
         if self.coordinator.data["sysParams"][self.entity_description.key] is None:
             return
 
-        value = self.self.coordinator.data["sysParams"][self.entity_description.key]
+        value = self.coordinator.data["sysParams"][self.entity_description.key]
 
         self._sync_state(value)
 

--- a/custom_components/econet300/entity.py
+++ b/custom_components/econet300/entity.py
@@ -56,10 +56,10 @@ class EconetEntity(CoordinatorEntity):
             "Update EconetEntity, entity name: %s", self.entity_description.name
         )
 
-        if self.coordinator.data[self.entity_description.key] is None:
+        if self.coordinator.data["sysParams"][self.entity_description.key] is None:
             return
 
-        value = self.coordinator.data[self.entity_description.key]
+        value = self.self.coordinator.data["sysParams"][self.entity_description.key]
 
         self._sync_state(value)
 
@@ -77,18 +77,20 @@ class EconetEntity(CoordinatorEntity):
 
         if (
             not self.coordinator.has_data(self.entity_description.key)
-            or self.coordinator.data[self.entity_description.key] is None
+            or self.coordinator.data["sysParams"][self.entity_description.key] is None
         ):
             _LOGGER.warning(
                 "Data key: %s was expected to exist but it doesn't",
                 self.entity_description.key,
             )
-            _LOGGER.debug("Coordinator available data: %s", self.coordinator.data)
+            _LOGGER.debug(
+                "Coordinator available data: %s", self.coordinator.data["sysParams"]
+            )
 
             _LOGGER.debug("Exiting async_added_to_hass method")
             return
 
-        value = self.coordinator.data[self.entity_description.key]
+        value = self.coordinator.data["sysParams"][self.entity_description.key]
 
         await super().async_added_to_hass()
         self._sync_state(value)

--- a/custom_components/econet300/number.py
+++ b/custom_components/econet300/number.py
@@ -45,7 +45,7 @@ class EconetNumber(EconetEntity, NumberEntity):
         coordinator: EconetDataCoordinator,
         api: Econet300Api,
     ):
-        """Initialize a new ecoNET number entyti."""
+        """Initialize a new ecoNET number entity."""
         self.entity_description = entity_description
         self.api = api
         super().__init__(coordinator)
@@ -67,7 +67,9 @@ class EconetNumber(EconetEntity, NumberEntity):
 
     async def async_set_limits_values(self):
         """Async Sync number limits."""
-        limits = await self.api.get_param_limits(self.entity_description.key)
+        limits = await self.api.fetch_rm_current_data_params_edits(
+            self.entity_description.key
+        )
         _LOGGER.debug("Number limits retrieved: %s", limits)
         if limits is None:
             _LOGGER.warning(
@@ -123,7 +125,7 @@ def apply_limits(desc: EconetNumberEntityDescription, limits: Limits):
 
 
 def create_number_entity_description(key: int) -> EconetNumberEntityDescription:
-    """Create Econect300 mixer sensor entity based on supplied key."""
+    """Create Econet300 mixer sensor entity based on supplied key."""
     map_key = NUMBER_MAP.get(str(key), str(key))
     _LOGGER.debug("Create number: %s", map_key)
     entity_description = EconetNumberEntityDescription(
@@ -154,7 +156,7 @@ async def async_setup_entry(
     entities: list[EconetNumber] = []
 
     for key in NUMBER_MAP:
-        number_limits = await api.get_param_limits(key)
+        number_limits = await api.fetch_rm_current_data_params_edits(key)
 
         if number_limits is None:
             _LOGGER.warning(

--- a/custom_components/econet300/number.py
+++ b/custom_components/econet300/number.py
@@ -58,12 +58,12 @@ class EconetNumber(EconetEntity, NumberEntity):
     def _sync_state(self, value):
         """Sync the state of the Econet number entity."""
         _LOGGER.debug("EconetNumber _sync_state: %s", value)
-        self._attr_native_value = value
+        self._attr_native_value = value["value"]
         map_key = NUMBER_MAP.get(self.entity_description.key)
 
         if map_key is not None:
-            self.set_native_min_value(ENTITY_MIN_VALUE.get(map_key))
-            self.set_native_max_value(ENTITY_MAX_VALUE.get(map_key))
+            self._attr_native_min_value = value["min"]
+            self._attr_native_max_value = value["max"]
         else:
             _LOGGER.error(
                 "EconetNumber _sync_state map_key %s not found in NUMBER_MAP",

--- a/custom_components/econet300/number.py
+++ b/custom_components/econet300/number.py
@@ -56,12 +56,20 @@ class EconetNumber(EconetEntity, NumberEntity):
         )
 
     def _sync_state(self, value):
-        """Sync state."""
+        """Sync the state of the Econet number entity."""
         _LOGGER.debug("EconetNumber _sync_state: %s", value)
         self._attr_native_value = value
         map_key = NUMBER_MAP.get(self.entity_description.key)
-        self._attr_native_min_value = ENTITY_MIN_VALUE.get(map_key)
-        self._attr_native_max_value = ENTITY_MAX_VALUE.get(map_key)
+
+        if map_key is not None:
+            self.set_native_min_value(ENTITY_MIN_VALUE.get(map_key))
+            self.set_native_max_value(ENTITY_MAX_VALUE.get(map_key))
+        else:
+            _LOGGER.error(
+                "EconetNumber _sync_state map_key %s not found in NUMBER_MAP",
+                self.entity_description.key,
+            )
+
         self.async_write_ha_state()
         self.hass.async_create_task(self.async_set_limits_values())
 

--- a/custom_components/econet300/number.py
+++ b/custom_components/econet300/number.py
@@ -112,7 +112,7 @@ class EconetNumber(EconetEntity, NumberEntity):
 
 def can_add(key: str, coordinator: EconetDataCoordinator):
     """Check if a given entity can be added based on the availability of data in the coordinator."""
-    return coordinator.has_data(key) and coordinator.data["sysParams"][key]
+    return coordinator.has_sys_data(key) and coordinator.data["sysParams"][key]
 
 
 def apply_limits(desc: EconetNumberEntityDescription, limits: Limits):

--- a/custom_components/econet300/number.py
+++ b/custom_components/econet300/number.py
@@ -67,9 +67,7 @@ class EconetNumber(EconetEntity, NumberEntity):
 
     async def async_set_limits_values(self):
         """Async Sync number limits."""
-        limits = await self.api.fetch_rm_current_data_params_edits(
-            self.entity_description.key
-        )
+        limits = await self.api.get_param_limits(self.entity_description.key)
         _LOGGER.debug("Number limits retrieved: %s", limits)
         if limits is None:
             _LOGGER.warning(
@@ -114,7 +112,7 @@ class EconetNumber(EconetEntity, NumberEntity):
 
 def can_add(key: str, coordinator: EconetDataCoordinator):
     """Check if a given entity can be added based on the availability of data in the coordinator."""
-    return coordinator.has_sys_data(key) and coordinator.data["sysParams"][key]
+    return coordinator.has_param_edit_data(key) and coordinator.data["paramsEdits"][key]
 
 
 def apply_limits(desc: EconetNumberEntityDescription, limits: Limits):
@@ -156,7 +154,8 @@ async def async_setup_entry(
     entities: list[EconetNumber] = []
 
     for key in NUMBER_MAP:
-        number_limits = await api.fetch_rm_current_data_params_edits(key)
+        number_limits = await api.get_param_limits(key)
+        _LOGGER.debug("Number limits retrieved: %s", number_limits)
 
         if number_limits is None:
             _LOGGER.warning(

--- a/custom_components/econet300/number.py
+++ b/custom_components/econet300/number.py
@@ -112,7 +112,7 @@ class EconetNumber(EconetEntity, NumberEntity):
 
 def can_add(key: str, coordinator: EconetDataCoordinator):
     """Check if a given entity can be added based on the availability of data in the coordinator."""
-    return coordinator.has_data(key) and coordinator.data[key]
+    return coordinator.has_data(key) and coordinator.data["sysParams"][key]
 
 
 def apply_limits(desc: EconetNumberEntityDescription, limits: Limits):

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -83,7 +83,7 @@ class MixerSensor(MixerEntity, EconetSensor):
 
 
 def create_entity_description(key: str) -> EconetSensorEntityDescription:
-    """Create Econect300 sensor entity based on supplied key."""
+    """Create Econet300 sensor entity based on supplied key."""
     _LOGGER.debug("Creating entity description for key: %s", key)
     entity_description = EconetSensorEntityDescription(
         key=key,
@@ -127,17 +127,17 @@ def can_add_mixer(key: str, coordinator: EconetDataCoordinator):
     _LOGGER.debug(
         "Checking if mixer can be added for key: %s, data %s",
         key,
-        coordinator.data["sysParams"],
+        coordinator.data["regParams"],
     )
     return (
-        coordinator.has_sys_data(key) and coordinator.data["sysParams"][key] is not None
+        coordinator.has_sys_data(key) and coordinator.data["regParams"][key] is not None
     )
 
 
 def create_mixer_sensor_entity_description(
     key: str, map_key: str
 ) -> EconetSensorEntityDescription:
-    """Create Econect300 mixer sensor entity based on supplied key."""
+    """Create Econet300 mixer sensor entity based on supplied key."""
     _LOGGER.debug(
         "Creating Mixer entity sensor description for key: %s, and type : %s",
         key,

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -22,7 +22,7 @@ from .const import (
     ENTITY_UNIT_MAP,
     ENTITY_VALUE_PROCESSOR,
     MIXER_MAP,
-    SENSOR_MAP,
+    SENSOR_MAP_KEY,
     SERVICE_API,
     SERVICE_COORDINATOR,
     STATE_CLASS_MAP,
@@ -84,19 +84,17 @@ class MixerSensor(MixerEntity, EconetSensor):
 
 def create_entity_description(key: str) -> EconetSensorEntityDescription:
     """Create Econect300 sensor entity based on supplied key."""
-    map_key = SENSOR_MAP.get(key, key)
-    _LOGGER.debug("SENSOR_MAP: %s", SENSOR_MAP)
-    _LOGGER.debug("Creating entity description for key: %s, map_key: %s", key, map_key)
+    _LOGGER.debug("Creating entity description for key: %s", key)
     entity_description = EconetSensorEntityDescription(
         key=key,
-        device_class=ENTITY_SENSOR_DEVICE_CLASS_MAP.get(map_key, None),
-        entity_category=ENTITY_CATEGORY.get(map_key, None),
-        translation_key=camel_to_snake(map_key),
-        icon=ENTITY_ICON.get(map_key, None),
-        native_unit_of_measurement=ENTITY_UNIT_MAP.get(map_key, None),
-        state_class=STATE_CLASS_MAP.get(map_key, None),
-        suggested_display_precision=ENTITY_PRECISION.get(map_key, None),
-        process_val=ENTITY_VALUE_PROCESSOR.get(map_key, lambda x: x),
+        device_class=ENTITY_SENSOR_DEVICE_CLASS_MAP.get(key, None),
+        entity_category=ENTITY_CATEGORY.get(key, None),
+        translation_key=camel_to_snake(key),
+        icon=ENTITY_ICON.get(key, None),
+        native_unit_of_measurement=ENTITY_UNIT_MAP.get(key, None),
+        state_class=STATE_CLASS_MAP.get(key, None),
+        suggested_display_precision=ENTITY_PRECISION.get(key, None),
+        process_val=ENTITY_VALUE_PROCESSOR.get(key, lambda x: x),
     )
     _LOGGER.debug("Created entity description: %s", entity_description)
     return entity_description
@@ -105,8 +103,8 @@ def create_entity_description(key: str) -> EconetSensorEntityDescription:
 def create_controller_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
     """Create controller sensor entities."""
     entities: list[EconetSensor] = []
-    coordinator_data = coordinator.data["sysParams"]
-    for data_key in SENSOR_MAP:
+    coordinator_data = coordinator.data["regParams"]
+    for data_key in SENSOR_MAP_KEY["_default"]:
         if data_key in coordinator_data:
             entities.append(
                 EconetSensor(create_entity_description(data_key), coordinator, api)
@@ -131,7 +129,9 @@ def can_add_mixer(key: str, coordinator: EconetDataCoordinator):
         key,
         coordinator.data["sysParams"],
     )
-    return coordinator.has_data(key) and coordinator.data["sysParams"][key] is not None
+    return (
+        coordinator.has_sys_data(key) and coordinator.data["sysParams"][key] is not None
+    )
 
 
 def create_mixer_sensor_entity_description(

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -61,6 +61,13 @@ class EconetSensor(EconetEntity, SensorEntity):
             self.entity_description,
         )
 
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        value = self.coordinator.data["regParams"].get(self.entity_description.key)
+        _LOGGER.debug("Sensor state for %s: %s", self.entity_description.key, value)
+        return value
+
     def _sync_state(self, value):
         """Sync state."""
         _LOGGER.debug("Update EconetSensor entity: %s", self.entity_description.name)

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -22,6 +22,7 @@ from .const import (
     ENTITY_UNIT_MAP,
     ENTITY_VALUE_PROCESSOR,
     MIXER_MAP,
+    PRODUCT_MODEL,
     SENSOR_MAP,
     SERVICE_API,
     SERVICE_COORDINATOR,
@@ -37,6 +38,7 @@ class EconetSensorEntityDescription(SensorEntityDescription):
     """Describes Econet sensor entity."""
 
     process_val: Callable[[Any], Any] = lambda x: x
+    device_keys: set[str] = PRODUCT_MODEL
 
 
 class EconetSensor(EconetEntity, SensorEntity):

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -130,7 +130,7 @@ def can_add_mixer(key: str, coordinator: EconetDataCoordinator):
         coordinator.data["regParams"],
     )
     return (
-        coordinator.has_sys_data(key) and coordinator.data["regParams"][key] is not None
+        coordinator.has_reg_data(key) and coordinator.data["regParams"][key] is not None
     )
 
 
@@ -154,10 +154,10 @@ def create_mixer_sensor_entity_description(key: str) -> EconetSensorEntityDescri
 def create_mixer_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
     """Create individual sensor descriptions for mixer sensors."""
     entities: list[MixerSensor] = []
-
+    # TODO: Cleanup logic add mixer only which not null in endpoint
     for i in range(1, AVAILABLE_NUMBER_OF_MIXERS + 1):
         string_mix = str(i)
-        mixer_keys = SENSOR_MIXER_KEY.get(string_mix, set())
+        mixer_keys = SENSOR_MIXER_KEY.get(string_mix)
         if mixer_keys:
             for key in mixer_keys:
                 if can_add_mixer(key, coordinator):

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -61,13 +61,6 @@ class EconetSensor(EconetEntity, SensorEntity):
             self.entity_description,
         )
 
-    @property
-    def state(self):
-        """Return the state of the sensor."""
-        value = self.coordinator.data["regParams"].get(self.entity_description.key)
-        _LOGGER.debug("Sensor state for %s: %s", self.entity_description.key, value)
-        return value
-
     def _sync_state(self, value):
         """Sync state."""
         _LOGGER.debug("Update EconetSensor entity: %s", self.entity_description.name)

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -22,7 +22,6 @@ from .const import (
     ENTITY_UNIT_MAP,
     ENTITY_VALUE_PROCESSOR,
     MIXER_MAP,
-    PRODUCT_MODEL,
     SENSOR_MAP,
     SERVICE_API,
     SERVICE_COORDINATOR,
@@ -38,7 +37,6 @@ class EconetSensorEntityDescription(SensorEntityDescription):
     """Describes Econet sensor entity."""
 
     process_val: Callable[[Any], Any] = lambda x: x
-    device_keys: set[str] = PRODUCT_MODEL
 
 
 class EconetSensor(EconetEntity, SensorEntity):

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -21,8 +21,8 @@ from .const import (
     ENTITY_SENSOR_DEVICE_CLASS_MAP,
     ENTITY_UNIT_MAP,
     ENTITY_VALUE_PROCESSOR,
-    MIXER_MAP,
     SENSOR_MAP_KEY,
+    SENSOR_MIXER_KEY,
     SERVICE_API,
     SERVICE_COORDINATOR,
     STATE_CLASS_MAP,
@@ -134,24 +134,18 @@ def can_add_mixer(key: str, coordinator: EconetDataCoordinator):
     )
 
 
-def create_mixer_sensor_entity_description(
-    key: str, map_key: str
-) -> EconetSensorEntityDescription:
-    """Create Econet300 mixer sensor entity based on supplied key."""
-    _LOGGER.debug(
-        "Creating Mixer entity sensor description for key: %s, and type : %s",
-        key,
-        map_key,
-    )
+def create_mixer_sensor_entity_description(key: str) -> EconetSensorEntityDescription:
+    """Create a sensor entity description for a mixer."""
+    _LOGGER.debug("Creating Mixer entity sensor description for key: %s", key)
     entity_description = EconetSensorEntityDescription(
         key=key,
-        translation_key=camel_to_snake(map_key),
-        icon=ENTITY_ICON.get(map_key, None),
-        native_unit_of_measurement=ENTITY_UNIT_MAP.get(map_key, None),
-        state_class=STATE_CLASS_MAP.get(map_key, None),
-        device_class=ENTITY_SENSOR_DEVICE_CLASS_MAP.get(map_key, None),
-        suggested_display_precision=ENTITY_PRECISION.get(map_key, 0),
-        process_val=ENTITY_VALUE_PROCESSOR.get(map_key, lambda x: x),
+        translation_key=camel_to_snake(key),
+        icon=ENTITY_ICON.get(key, None),
+        native_unit_of_measurement=ENTITY_UNIT_MAP.get(key, None),
+        state_class=STATE_CLASS_MAP.get(key, None),
+        device_class=ENTITY_SENSOR_DEVICE_CLASS_MAP.get(key, None),
+        suggested_display_precision=ENTITY_PRECISION.get(key, 0),
+        process_val=ENTITY_VALUE_PROCESSOR.get(key, lambda x: x),
     )
     _LOGGER.debug("Created Mixer entity description: %s", entity_description)
     return entity_description
@@ -163,23 +157,19 @@ def create_mixer_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
 
     for i in range(1, AVAILABLE_NUMBER_OF_MIXERS + 1):
         string_mix = str(i)
-        mixer_map_value = MIXER_MAP.get(string_mix)
-        if mixer_map_value is not None:
-            for key, value in mixer_map_value.items():
+        mixer_keys = SENSOR_MIXER_KEY.get(string_mix, set())
+        if mixer_keys:
+            for key in mixer_keys:
                 if can_add_mixer(key, coordinator):
-                    mixer_sensor_entity = create_mixer_sensor_entity_description(
-                        key, value
-                    )
+                    mixer_sensor_entity = create_mixer_sensor_entity_description(key)
                     entities.append(
                         MixerSensor(mixer_sensor_entity, coordinator, api, i)
                     )
                 else:
-                    _LOGGER.warning(
-                        "Mixer: %s , Sensor: %s %s wont be added", i, key, value
-                    )
+                    _LOGGER.warning("Mixer: %s , Sensor: %s won't be added", i, key)
         else:
             _LOGGER.debug(
-                "Mixer: %s not defined in const, wont be added",
+                "Mixer: %s not defined in const, won't be added",
                 i,
             )
 

--- a/custom_components/econet300/sensor.py
+++ b/custom_components/econet300/sensor.py
@@ -105,7 +105,7 @@ def create_entity_description(key: str) -> EconetSensorEntityDescription:
 def create_controller_sensors(coordinator: EconetDataCoordinator, api: Econet300Api):
     """Create controller sensor entities."""
     entities: list[EconetSensor] = []
-    coordinator_data = coordinator.data
+    coordinator_data = coordinator.data["sysParams"]
     for data_key in SENSOR_MAP:
         if data_key in coordinator_data:
             entities.append(
@@ -127,9 +127,11 @@ def create_controller_sensors(coordinator: EconetDataCoordinator, api: Econet300
 def can_add_mixer(key: str, coordinator: EconetDataCoordinator):
     """Check if a mixer can be added."""
     _LOGGER.debug(
-        "Checking if mixer can be added for key: %s, data %s", key, coordinator.data
+        "Checking if mixer can be added for key: %s, data %s",
+        key,
+        coordinator.data["sysParams"],
     )
-    return coordinator.has_data(key) and coordinator.data[key] is not None
+    return coordinator.has_data(key) and coordinator.data["sysParams"][key] is not None
 
 
 def create_mixer_sensor_entity_description(

--- a/custom_components/econet300/strings.json
+++ b/custom_components/econet300/strings.json
@@ -38,8 +38,8 @@
       "fan_works": {
         "name": "Fan"
       },
-      "aditional_feeder": {
-        "name": "Aditional feeder"
+      "additional_feeder": {
+        "name": "Additional feeder"
       },
       "pump_fireplace_works": {
         "name": "Boiler Pump"

--- a/custom_components/econet300/translations/en.json
+++ b/custom_components/econet300/translations/en.json
@@ -38,8 +38,8 @@
       "fan_works": {
         "name": "Fan"
       },
-      "aditional_feeder": {
-        "name": "Aditional feeder"
+      "additional_feeder": {
+        "name": "Additional feeder"
       },
       "pump_fireplace_works": {
         "name": "Boiler Pump"


### PR DESCRIPTION
This pull request includes various changes to the `econet300` integration, focusing on refactoring the API methods, improving logging, and updating constant values. The most important changes include renaming methods for clarity, adding new API endpoints, and enhancing the logging and error handling mechanisms.

### Refactoring and Method Renaming:

* Renamed `get_params` to `fetch_sys_params` to better describe its functionality and added more detailed logging. [[1]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55L95-R107) [[2]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55L207-R204)
* Renamed `fetch_data` to `fetch_reg_params_data` and added error handling for data fetching.

### Logging Improvements:

* Added detailed logging in methods to provide better insights into the execution flow and data fetching processes. [[1]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55L111-R116) [[2]](diffhunk://#diff-f376f6a9888eb2cbb87091df262753dbe2416cb429f8d38a848376825c02ddbcR64-R68)

### Constants and Configuration:

* Introduced new constants for sensor and binary sensor mappings, and updated existing ones for better clarity and usage. [[1]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eR106-R146) [[2]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eL275-R312)
* Updated `.vscode/settings.json` to include new words in the spell checker configuration.

### Error Handling:

* Enhanced error handling in data fetching methods to log errors and handle missing data gracefully. [[1]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55R327-R356) [[2]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55R284-R313)

### Code Cleanup:

* Fixed typos and removed redundant debug statements to clean up the codebase. [[1]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55L1-R1) [[2]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55L39-R41) [[3]](diffhunk://#diff-64e350b8205ada21d8f2ab6cdaec012c8564f0334e7adaf2b47171aa8c7d9c55L164-L172)