### PR TITLE
Refactor

### DIFF
--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -22,7 +22,6 @@ from .const import (
     API_SYS_PARAMS_PARAM_SW_REV,
     API_SYS_PARAMS_PARAM_UID,
     API_SYS_PARAMS_URI,
-    EDITABLE_PARAMS_MAPPING_TABLE,
 )
 from .mem_cache import MemCache
 

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -29,14 +29,6 @@ from .mem_cache import MemCache
 _LOGGER = logging.getLogger(__name__)
 
 
-def map_param(param_name):
-    """Check params mapping in const.py."""
-    if param_name not in EDITABLE_PARAMS_MAPPING_TABLE:
-        return None
-
-    return EDITABLE_PARAMS_MAPPING_TABLE[param_name]
-
-
 class Limits:
     """Class defining entity value set limits."""
 

--- a/custom_components/econet300/api.py
+++ b/custom_components/econet300/api.py
@@ -28,18 +28,6 @@ from .mem_cache import MemCache
 _LOGGER = logging.getLogger(__name__)
 
 
-class Limits:
-    """Class defining entity value set limits."""
-
-    def __init__(self, min_v: int | None, max_v: int | None):
-        """Construct the necessary attributes for the Limits object."""
-        self.min = min_v
-        self.max = max_v
-
-    class AuthError(Exception):
-        """Raised when authentication fails."""
-
-
 class AuthError(Exception):
     """Raised when authentication fails."""
 
@@ -50,6 +38,18 @@ class ApiError(Exception):
 
 class DataError(Exception):
     """Raised when there is an error with the data."""
+
+
+class Limits:
+    """Class defining entity value set limits."""
+
+    def __init__(self, min_v: int | None, max_v: int | None):
+        """Construct the necessary attributes for the Limits object."""
+        self.min = min_v
+        self.max = max_v
+
+    class AuthError(Exception):
+        """Raised when authentication fails."""
 
 
 class EconetClient:

--- a/custom_components/econet300/common_functions.py
+++ b/custom_components/econet300/common_functions.py
@@ -1,4 +1,4 @@
-"""Functionsd used in Econet300 integration,."""
+"""Functions used in Econet300 integration,."""
 
 import re
 

--- a/custom_components/econet300/common_functions.py
+++ b/custom_components/econet300/common_functions.py
@@ -7,11 +7,3 @@ def camel_to_snake(key: str) -> str:
     """Convert camel case return from API to snake case to match translations keys structure."""
     key = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", key)
     return re.sub("([a-z0-9])([A-Z])", r"\1_\2", key).lower()
-
-
-def get_key_by_value(search_dict: dict, search_value: str) -> str | None:
-    """Get a key from a dict by passing its value."""
-    for key, value in search_dict.items():
-        if value == search_value:
-            return key
-    return None

--- a/custom_components/econet300/config_flow.py
+++ b/custom_components/econet300/config_flow.py
@@ -6,8 +6,8 @@ import logging
 from typing import Any
 
 from homeassistant import config_entries
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import voluptuous as vol
 
@@ -18,7 +18,6 @@ from .mem_cache import MemCache
 
 _LOGGER = logging.getLogger(__name__)
 
-# TODO adjust the data schema to the data that you need
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required("host"): str,
@@ -52,7 +51,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(
@@ -67,7 +66,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors["base"] = "cannot_connect"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -6,9 +6,7 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
-    STATE_CLOSING,
     STATE_OFF,
-    STATE_OPENING,
     STATE_PAUSED,
     STATE_PROBLEM,
     STATE_UNKNOWN,
@@ -30,12 +28,6 @@ DEVICE_INFO_MIXER_NAME = "Mixer device"
 
 CONF_ENTRY_TITLE = "ecoNET300"
 CONF_ENTRY_DESCRIPTION = "PLUM Econet300"
-
-SERVO_MIXER_VALVE_HA_STATE: dict[int, str] = {
-    0: STATE_CLOSING,
-    1: STATE_OFF,
-    2: STATE_OPENING,
-}
 
 ## Sys params
 API_SYS_PARAMS_URI = "sysParams"
@@ -82,24 +74,12 @@ API_EDIT_PARAM_URI = "rmCurrNewParam"
 API_EDITABLE_PARAMS_LIMITS_URI = "rmCurrentDataParamsEdits"
 API_EDITABLE_PARAMS_LIMITS_DATA = "data"
 
-EDITABLE_PARAMS_MAPPING_TABLE = {
-    "tempCOSet": "1280",
-    "tempCWUSet": "1281",
-    "mixerSetTemp1": "1287",
-    "mixerSetTemp2": "1288",
-    "mixerSetTemp3": "1289",
-    "mixerSetTemp4": "1290",
-    "mixerSetTemp5": "1291",
-    "mixerSetTemp6": "1292",
-}
-
 ###################################
 #    NUMBER of AVAILABLE MIXERS
 ###################################
 AVAILABLE_NUMBER_OF_MIXERS = 6
 MIXER_AVAILABILITY_KEY = "mixerTemp"
 MIXER_SET_AVAILABILITY_KEY = "mixerSetTemp"
-MIXER_KEY = "mixerPumpWorks"
 
 # Dynamically generate SENSOR_MIXER_KEY
 SENSOR_MIXER_KEY = {
@@ -146,57 +126,9 @@ BINARY_SENSOR_MAP_KEY = {
     },
 }
 
-SENSOR_MAP = {
-    "26": "tempFeeder",
-    "28": "tempExternalSensor",
-    "97": "fuelLevel",
-    "151": "lambdaStatus",
-    "153": "lambdaSet",
-    "154": "lambdaLevel",
-    "155": "workAt100",
-    "156": "workAt50",
-    "157": "workAt30",
-    "158": "FeederWork",
-    "159": "FiringUpCount",
-    "168": "main_server",
-    "170": "signal",
-    "171": "status_wifi",
-    "1024": "tempCO",
-    "1025": "tempCWU",
-    "1028": "tempUpperBuffer",
-    "1029": "tempLowerBuffer",
-    "1030": "tempFlueGas",
-    "1792": "mode",
-    "1794": "boilerPower",
-    "1795": "fanPower",
-    "1280": "tempCOSet",
-    "1281": "tempCWUSet",
-}
-
-MIXER_MAP = {
-    "1": {
-        "139": "valveMixer1",
-        "143": "servoMixer1",
-        "1031": "mixerTemp1",
-        "1287": "mixerSetTemp1",
-    }
-}
-
 NUMBER_MAP = {
     "1280": "tempCOSet",
     "1281": "tempCWUSet",
-}
-
-BINARY_SENSOR_MAP = {
-    "1": "lighter",
-    "111": "weatherControl",
-    "113": "unseal",
-    "117": "thermostat",
-    "118": "pumpCOWorks",
-    "1536": "fanWorks",
-    "1540": "additionalFeeder",
-    "1541": "pumpFireplaceWorks",
-    "1542": "pumpCWUWorks",
 }
 
 ENTITY_UNIT_MAP = {
@@ -321,22 +253,15 @@ ENTITY_BINARY_DEVICE_CLASS_MAP = {
 ENTITY_PRECISION = {
     "tempFeeder": 1,
     "tempExternalSensor": 1,
-    "fuelLevel": 0,
     "lambdaLevel": 1,
     "lambdaSet": 1,
     "tempCO": 1,
-    "tempCOSet": 0,
-    "tempCWUSet": 0,
-    "fanPower": 0,
-    "mixerSetTemp1": 0,
     "mixerTemp1": 1,
     "tempBack": 2,
     "tempUpperBuffer": 1,
     "tempLowerBuffer": 1,
     "tempCWU": 1,
     "tempFlueGas": 1,
-    "mixerTemp": 0,
-    "mixerSetTemp": 0,
 }
 
 ENTITY_ICON = {
@@ -395,7 +320,6 @@ ENTITY_VALUE_PROCESSOR = {
     ),
     "status_wifi": lambda x: "Connected" if x == 1 else "Disconnected",
     "main_server": lambda x: "Server available" if x == 1 else "Server not available",
-    "servoMixer1": lambda x: SERVO_MIXER_VALVE_HA_STATE.get(x, STATE_UNKNOWN),
     "statusCWU": lambda x: "Not set" if x == NO_CWU_TEMP_SET_STATUS_CODE else "Set",
 }
 
@@ -437,19 +361,4 @@ ENTITY_STEP = {
 ENTITY_VISIBLE = {
     "tempCOSet": True,
     "tempCWUSet": True,
-}
-
-# Default values for visible 'entity_registry_visible_default=False,' in sensor.py
-REG_PARAM_VISIBLE_DEFAULT = {
-    "tempUpperBuffer": False,
-    "tempLowerBuffer": False,
-}
-
-PRODUCT_MODEL = {
-    # Models name which known us connect with ecoNET300
-    "ecoMAX810P-L TOUCH"
-    "SControl MK1"
-    "ecoMAX860P2-N TOUCH"
-    "ecoMAX860P3-V"
-    "ecoSOL 301"
 }

--- a/custom_components/econet300/const.py
+++ b/custom_components/econet300/const.py
@@ -126,11 +126,13 @@ SENSOR_MAP_KEY = {
         "fuelLevel",
         "tempCO",
         "tempCOSet",
+        "statusCWU",
         "tempCWUSet",
         "tempFlueGas",
         "mode",
         "fanPower",
         "thermostat",
+        "tempExternalSensor",
     },
 }
 
@@ -274,6 +276,7 @@ ENTITY_SENSOR_DEVICE_CLASS_MAP: dict[str, SensorDeviceClass | None] = {
     "mixerSetTemp": SensorDeviceClass.TEMPERATURE,
     "tempBack": SensorDeviceClass.TEMPERATURE,
     "tempCWU": SensorDeviceClass.TEMPERATURE,
+    "statusCWU": None,
     "tempUpperBuffer": SensorDeviceClass.TEMPERATURE,
     "tempLowerBuffer": SensorDeviceClass.TEMPERATURE,
     "signal": SensorDeviceClass.SIGNAL_STRENGTH,
@@ -306,7 +309,6 @@ ENTITY_BINARY_DEVICE_CLASS_MAP = {
     "lighter": BinarySensorDeviceClass.RUNNING,
     "weatherControl": BinarySensorDeviceClass.RUNNING,
     "unseal": BinarySensorDeviceClass.RUNNING,
-    #    "thermostat": BinarySensorDeviceClass.RUNNING,
     "pumpCOWorks": BinarySensorDeviceClass.RUNNING,
     "fanWorks": BinarySensorDeviceClass.RUNNING,
     "additionalFeeder": BinarySensorDeviceClass.RUNNING,
@@ -343,6 +345,7 @@ ENTITY_ICON = {
     "temCO": "mdi:thermometer-lines",
     "tempCOSet": "mdi:thermometer-chevron-up",
     "tempCWUSet": "mdi:thermometer-chevron-up",
+    "statusCWU": "mdi:water-boiler",
     "thermostat": "mdi:thermostat",
     "boilerPower": "mdi:gauge",
     "fuelLevel": "mdi:gas-station",
@@ -376,7 +379,10 @@ ENTITY_ICON_OFF = {
     "additionalFeeder": "mdi:screw-lag",
     "pumpFireplaceWorks": "mdi:pump-off",
     "pumpCWUWorks": "mdi:pump-off",
+    "statusCWU": "mdi:water-boiler-off",
 }
+
+NO_CWU_TEMP_SET_STATUS_CODE = 128
 
 ENTITY_VALUE_PROCESSOR = {
     "mode": lambda x: OPERATION_MODE_NAMES.get(x, STATE_UNKNOWN),
@@ -390,6 +396,7 @@ ENTITY_VALUE_PROCESSOR = {
     "status_wifi": lambda x: "Connected" if x == 1 else "Disconnected",
     "main_server": lambda x: "Server available" if x == 1 else "Server not available",
     "servoMixer1": lambda x: SERVO_MIXER_VALVE_HA_STATE.get(x, STATE_UNKNOWN),
+    "statusCWU": lambda x: "Not set" if x == NO_CWU_TEMP_SET_STATUS_CODE else "Set",
 }
 
 

--- a/custom_components/econet300/strings.json
+++ b/custom_components/econet300/strings.json
@@ -129,6 +129,9 @@
       "pump_cwu_works": {
         "name": "HUW pump"
       },
+      "status_cwu": {
+        "name": "Water heater status"
+      },
       "pump_fireplace_works": {
         "name": "Boiler pump"
       },

--- a/custom_components/econet300/translations/en.json
+++ b/custom_components/econet300/translations/en.json
@@ -129,6 +129,9 @@
       "pump_cwu_works": {
         "name": "HUW pump"
       },
+      "status_cwu": {
+        "name": "Water heater status"
+      },
       "pump_fireplace_works": {
         "name": "Boiler pump"
       },


### PR DESCRIPTION
[Copilot is generating
This pull request includes several changes to the `econet300` custom component, focusing on error handling, configuration flow, and constants cleanup. The most important changes include the addition of custom exceptions, updates to the configuration flow to use `ConfigFlowResult`, and significant cleanup of the constants file to remove unused mappings and improve readability.

### Error Handling Improvements:
* Added custom exceptions `AuthError`, `ApiError`, and `DataError` to handle specific error cases in `custom_components/econet300/api.py`.

### Configuration Flow Updates:
* Updated the configuration flow to use `ConfigFlowResult` instead of `FlowResult` for better type clarity in `custom_components/econet300/config_flow.py`. [[1]](diffhunk://#diff-c6de0a4067ef2c097d5aef677632f307afa1a281dd538bce4c1c2a186e99c230R9-L10) [[2]](diffhunk://#diff-c6de0a4067ef2c097d5aef677632f307afa1a281dd538bce4c1c2a186e99c230L55-R54)

### Constants Cleanup:
* Removed unused constants and mappings, such as `EDITABLE_PARAMS_MAPPING_TABLE`, `SENSOR_MAP`, `MIXER_MAP`, and `BINARY_SENSOR_MAP` from `custom_components/econet300/const.py`. [[1]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eL34-L39) [[2]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eL147-L199) [[3]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eR211)
* Added new constants and updated mappings to improve readability and maintainability, including `NO_CWU_TEMP_SET_STATUS_CODE` and updates to `ENTITY_UNIT_MAP` and `ENTITY_ICON`. [[1]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eR307-R311) [[2]](diffhunk://#diff-8cca424931b02c5d07f6f2870d1dbe93d41d74176b35a91b08a0384c016db90eL434-L448)

### Documentation and Typo Fixes:
* Fixed a typo in the module docstring in `custom_components/econet300/common_functions.py`.

### Translation Updates:
* Added a new translation key for `status_cwu` in `custom_components/econet300/strings.json` and `custom_components/econet300/translations/en.json`. [[1]](diffhunk://#diff-313f4a15642ed51041f5443ead757334061411833a65a91327bbed1bf036f8d1R132-R134) [[2]](diffhunk://#diff-f268b531d8ee8396919bf3e9a02b6d20da5640a284b2062af1cf21cc149c73caR132-R134) a summary...]