### PR TITLE
fix: add MIT license for HACS validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- **MIT license**: added a root `LICENSE` file so GitHub and HACS can detect the repository license (fixes HACS `check-license`).
+
 ## [v1.3.0] - 2026-07-01
 
 Stable release consolidating the `1.3.0-beta.1` … `1.3.0-beta.7` pre-releases.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023-2026 jontofront and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@ This integration is not officially affiliated with or endorsed by Plum Sp. z o.o
 
 ---
 
+## 📄 License
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
 ## 📞 Support
 
 If you encounter any issues or have questions:


### PR DESCRIPTION
## Summary
- Add a root MIT \LICENSE\ so GitHub Licensee can detect the repository license.
- Fixes HACS Validate \check-license\ (\The repository has no license\).
- Document the license in README and CHANGELOG.

## Test plan
- [ ] Confirm GitHub shows the MIT license on the repo after merge to \master\.
- [ ] Confirm the scheduled/manual **Validate hacs** workflow passes \check-license\.
